### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Once `profiles.clj` is installed, run `lein repl`.
 
 ### pull
 
-How many times have you forgotten a library dependency for `project.clj` and then had to restart your nrepl? `pull` is a convienient wrapper around the `pomegranate` library:
+How many times have you forgotten a library dependency for `project.clj` and then had to restart your nrepl? `pull` is a convenient wrapper around the `pomegranate` library:
 
 ```clojure
 > (require 'hiccup.core)


### PR DESCRIPTION
@zcaudate, I've corrected a typographical error in the documentation of the [vinyasa](https://github.com/zcaudate/vinyasa) project. Specifically, I've changed convienient to convenient. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.